### PR TITLE
Bypasses cloudflares bot detection

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,9 +5,11 @@ RUN echo "http://dl-4.alpinelinux.org/alpine/v3.14/main" >> /etc/apk/repositorie
     echo "http://dl-4.alpinelinux.org/alpine/v3.14/community" >> /etc/apk/repositories && \
     apk update
 
-RUN apk add chromium chromium-chromedriver && \
+RUN apk add chromium chromium-chromedriver xvfb && \
     pip install selenium && \
-    pip install requests
+    pip install requests && \
+    pip install undetected_chromedriver && \
+    pip install pyvirtualdisplay
 
 COPY script.py /script.py
 CMD ["python", "-u", "/script.py"]

--- a/script.py
+++ b/script.py
@@ -1,7 +1,7 @@
 from dataclasses import dataclass
-from selenium import webdriver
 from selenium.webdriver.common.by import By
-from selenium.webdriver.chrome.options import Options
+import undetected_chromedriver as Uc
+from pyvirtualdisplay import Display
 import time
 import requests
 import os
@@ -28,14 +28,16 @@ class KeyScanner:
         self.poll_rate = 1.5
         self.winners = []
         self.checker = [0,0]
-        self.chrome_options = Options()
-        if headless:
-            self.chrome_options.add_argument('--headless')
-            self.chrome_options.add_argument('--no-sandbox')
-        self.chrome_options.add_argument('--disable-dev-shm-usage')
-        prefs = {"profile.managed_default_content_settings.images": 2}
-        self.chrome_options.add_experimental_option("prefs", prefs)
-        self.driver = webdriver.Chrome(options=self.chrome_options)
+        #self.chrome_options = Options()
+        #if headless:
+            #self.chrome_options.add_argument('--headless')
+            #self.chrome_options.add_argument('--no-sandbox')
+        #self.chrome_options.add_argument('--disable-dev-shm-usage')
+        #prefs = {"profile.managed_default_content_settings.images": 2}
+        #self.chrome_options.add_experimental_option("prefs", prefs)
+        self.display = Display(visible=False, size=(800, 600))
+        self.display.start()
+        self.driver = Uc.Chrome(driver_executable_path='/usr/bin/chromedriver')
     
     def notify(self, scan:Scan):
         message = f"Raffle will begin in {self.format(scan.timer)} there are {scan.keys} keys available.\nClick [here]({self.website_url}) to go to the website."


### PR DESCRIPTION
I changed the bot to use the webdriver from the 'undetected_chromedriver' pip package which bypasses cloudflare's bot detection. When ran in headless mode, cloudflare would be able to detect it so instead of running in headless mode, it uses the 'pyvirtualdisplay' pip package to make a invisible virtual display using xvfb and then the browser runs in that.